### PR TITLE
「🔨」 fix(Wastebin): Change to the new domain (old one is deprecated)

### DIFF
--- a/lua/plugins/wastebin.lua
+++ b/lua/plugins/wastebin.lua
@@ -3,7 +3,7 @@ return {
     "matze/wastebin.nvim",
     config = function ()
 		require("wastebin").setup({
-			url = "https://wastebin.vaultzox.duckdns.org",
+			url = "https://paste.keyzox.me",
 			--	To open it on default internet browser (works with xdg)
 			open_cmd = "open",
 			--	If on wayland (pkgs : wl-clipboard)


### PR DESCRIPTION
*https://wastebin.vaultzox.duckdns.org* is deprecated (and does not work anymore)
Now gone with [https://paste.keyzox.me](https://paste.keyzox.me) because way easier to remember